### PR TITLE
Fixed attribute sorting to ordinal of chars

### DIFF
--- a/SmevTransform.NET/Comparators/AttributeSortingComparator.cs
+++ b/SmevTransform.NET/Comparators/AttributeSortingComparator.cs
@@ -23,21 +23,22 @@ namespace SmevTransform.NET.Comparators
             if (string.IsNullOrEmpty(attr1.getUri()) && string.IsNullOrEmpty(attr2.getUri()))
             {
                 // compare attribute names
-                return attr1.getName().CompareTo(attr2.getName());
+                return string.CompareOrdinal(attr1.getName(), attr2.getName());
             }
 
             // both attributes are in unqualified form
             if (!string.IsNullOrEmpty(attr1.getUri()) && !string.IsNullOrEmpty(attr2.getUri()))
             {
                 // compare namespace
-                var nsComparsionResult = attr1.getUri().CompareTo(attr2.getUri());
+                var nsComparsionResult = string.CompareOrdinal(attr1.getUri(), attr2.getUri());
                 if (nsComparsionResult != 0)
                     return nsComparsionResult;
                 else
-                    return attr1.getName().CompareTo(attr2.getName());
+                    return string.CompareOrdinal(attr1.getName(), attr2.getName());
             }
 
             return string.IsNullOrEmpty(attr1.getUri()) ? 1 : -1;
         }
+        
     }
 }

--- a/SmevTransform.Tests/AttributeSortingComparatorTest.cs
+++ b/SmevTransform.Tests/AttributeSortingComparatorTest.cs
@@ -82,5 +82,16 @@ namespace SmevTransform.Tests
 
             Assert.That(result, Is.GreaterThan(0));
         }
+
+        [Test]
+        public void CompareOrdinalSort()
+        {
+            var attr1 = new Attribute("Bob", "value1");
+            var attr2 = new Attribute("alice", "value2");
+
+            var result = new AttributeSortingComparator().Compare(attr1, attr2);
+
+            Assert.That(result, Is.LessThan(0));
+        }
     }
 }


### PR DESCRIPTION
В эталонной реализации трансформа в МР СМЭВ-3 (на Java) при упорядочивании атрибутов используется метод "compareTo()", который производит сравнение символов на основе их кодов, т.е. "B" > "a". В NET метод "CompareTo()" сравнивает в алфавитном порядке, не учитывая регистра, т.е. для него "B" < "a". 
Изменил сравнение на string.CompareOrdinal(), добавил тест 